### PR TITLE
Fix weights when score is perfect

### DIFF
--- a/Fuse/Classes/Fuse.swift
+++ b/Fuse/Classes/Fuse.swift
@@ -383,7 +383,7 @@ extension Fuse {
                 
                 if let result = self.search(pattern, in: value) {
                     let weight = property.weight == 1 ? 1 : 1 - property.weight
-                    let score = result.score * weight
+                    let score = (result.score == 0 && weight == 1 ? 0.001 : result.score) * weight
                     totalScore += score
                     
                     scores.append(score)


### PR DESCRIPTION
Hey, thanks for this lovely library!

I noticed an issue where the score would equal 0 no matter the weights when having a perfect match on a property. 
Looking into Fusejs I found that they fallback to 0.001 when this is the case to account that issue.
This PR adds the exact same fallback.

I haven't looked into what different approaches your library uses to calculate the score compared to FuseJS so I'm not really sure whether the fallback number should be any different or not?