### PR TITLE
Performance improvements

### DIFF
--- a/Fuse/Classes/String+Fuse.swift
+++ b/Fuse/Classes/String+Fuse.swift
@@ -31,7 +31,7 @@ extension String {
             return nil
         }
         
-        if self.startIndex.encodedOffset + position > self.endIndex.encodedOffset {
+        if self.count < position {
             return nil
         }
         


### PR DESCRIPTION
Several improvements to the internals of `_search(_:in:)` to avoid the less efficient parts of Swift's `String` implementation, namely the fact that `count` is O(n) for a string of length n, and `String.index(_, offsetBy: n)` is also O(n).

Overall speedup of up to 2.5x for search operations.

FuseUtilities.swift:
- add a version of `calculateScore` which takes a `patternLength` parameter, to avoid repeated calls to `String.count`, which is O(n) for a string of length n.
- `calculatePatternAlphabet`: eliminate unnecessary loop zeroing `mask` by using nil coalescing instead.
- `calculatePatternAlphabet`: eliminate unnecessary calls to `String.index(_, offsetBy: n)`, which is O(n), by instead looping through pattern.enumerated().
- findRanges: eliminate unnecessary variable `end` and unnecessary subtraction of one, using `..<` instead of `...` operator.

Fuse.swift:
- change all calls to `calculateScore` to use `pattern.len` (see FuseUtilities.swift)
- calculate `text.count` only once
- eliminate unnecessary `Double`/`Int` conversions in calculation of `binMid`
- avoid calls to `text.char(at:)`, which is O(n+j) for offset of j in string length n, instead calculate index of `currentLocation` once, then apply `String.index(before:)` once per loop iteration, which is O(1).

String+Fuse.swift:
- avoid deprecated `encodedOffset` and instead compare `self.count` to `position`