### PR TITLE
Fix parameters naming to reflect semantics better

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -64,25 +64,20 @@ class Tests: XCTestCase {
     
     func testProtocolWeightedSearch1() {
         struct Book: Fuseable {
-            let author: String
             let title: String
-            
-            public init (author: String, title: String) {
-                self.author = author
-                self.title = title
-            }
+            let author: String
             
             var properties: [FuseProperty] {
                 return [
-                    FuseProperty(name: title, weight: 0.7),
-                    FuseProperty(name: author, weight: 0.3),
+                    FuseProperty(value: title, weight: 0.7),
+                    FuseProperty(value: author, weight: 0.3)
                 ]
             }
         }
         
         let books: [Book] = [
-            Book(author: "John X", title: "Old Man's War fiction"),
-            Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+            Book(title: "Old Man's War fiction", author: "John X"),
+            Book(title: "Right Ho Jeeves", author: "P.D. Mans")
         ]
         
         let fuse = Fuse()
@@ -95,25 +90,20 @@ class Tests: XCTestCase {
     
     func testProtocolWeightedSearch2() {
         struct Book: Fuseable {
-            let author: String
             let title: String
-            
-            public init (author: String, title: String) {
-                self.author = author
-                self.title = title
-            }
+            let author: String
             
             var properties: [FuseProperty] {
                 return [
-                    FuseProperty(name: title, weight: 0.3),
-                    FuseProperty(name: author, weight: 0.7),
+                    FuseProperty(value: title, weight: 0.3),
+                    FuseProperty(value: author, weight: 0.7)
                 ]
             }
         }
         
         let books: [Book] = [
-            Book(author: "John X", title: "Old Man's War fiction"),
-            Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+            Book(title: "Old Man's War fiction", author: "John X"),
+            Book(title: "Right Ho Jeeves", author: "P.D. Mans")
         ]
         
         let fuse = Fuse()
@@ -185,25 +175,20 @@ class Tests: XCTestCase {
     
     func testProtocolWeightedSearchTokenized() {
         struct Book: Fuseable {
-            let author: String
             let title: String
-            
-            public init (author: String, title: String) {
-                self.author = author
-                self.title = title
-            }
+            let author: String
             
             var properties: [FuseProperty] {
                 return [
-                    FuseProperty(name: title, weight: 0.5),
-                    FuseProperty(name: author, weight: 0.5),
+                    FuseProperty(value: title, weight: 0.5),
+                    FuseProperty(value: author, weight: 0.5)
                 ]
             }
         }
         
         let books: [Book] = [
-            Book(author: "John X", title: "Old Man's War fiction"),
-            Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+            Book(title: "Old Man's War fiction", author: "John X"),
+            Book(title: "Right Ho Jeeves", author: "P.D. Mans")
         ]
         
         let fuse = Fuse(tokenize: true)
@@ -219,15 +204,10 @@ class Tests: XCTestCase {
             let author: String
             let title: String
             
-            public init (author: String, title: String) {
-                self.author = author
-                self.title = title
-            }
-            
             var properties: [FuseProperty] {
                 return [
-                    FuseProperty(name: title, weight: 0.5),
-                    FuseProperty(name: author, weight: 0.5),
+                    FuseProperty(value: title, weight: 0.5),
+                    FuseProperty(value: author, weight: 0.5)
                 ]
             }
         }

--- a/Fuse/Classes/Fuse.swift
+++ b/Fuse/Classes/Fuse.swift
@@ -9,15 +9,12 @@
 import Foundation
 
 public struct FuseProperty {
-    let name: String
+    let value: String
     let weight: Double
     
-    public init (name: String) {
-        self.init(name: name, weight: 1)
-    }
+    public init (value: String, weight: Double = 1.0) {
+        self.value = value
     
-    public init (name: String, weight: Double) {
-        self.name = name
         self.weight = weight
     }
 }
@@ -42,7 +39,7 @@ public class Fuse {
         index: Int,
         score: Double,
         results: [(
-            key: String,
+            value: String,
             score: Double,
             ranges: [CountableClosedRange<Int>]
         )]
@@ -375,7 +372,7 @@ extension Fuse {
     
     /// Searches for a text pattern in an array of `Fuseable` objects.
     ///
-    /// Each `FuseSearchable` object contains a `properties` accessor which returns `FuseProperty` array. Each `FuseProperty` is a tuple containing a `key` (the value of the property which should be included in the search), and a `weight` (how much "weight" to assign to the score)
+    /// Each `FuseSearchable` object contains a `properties` accessor which returns `FuseProperty` array. Each `FuseProperty` is a tuple containing a `value` (the value of the property which should be included in the search), and a `weight` (how much "weight" to assign to the score)
     ///
     /// ## Example
     ///
@@ -387,8 +384,8 @@ extension Fuse {
     ///
     ///         var properties: [FuseProperty] {
     ///             return [
-    ///                 FuseProperty(name: title, weight: 0.3),
-    ///                 FuseProperty(name: author, weight: 0.7),
+    ///                 FuseProperty(value: title, weight: 0.7),
+    ///                 FuseProperty(value: author, weight: 0.3)
     ///             ]
     ///         }
     ///     }
@@ -396,8 +393,8 @@ extension Fuse {
     /// Searching is straightforward:
     ///
     ///     let books: [Book] = [
-    ///         Book(author: "John X", title: "Old Man's War fiction"),
-    ///         Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+    ///         Book(title: "Old Man's War fiction", author: "John X"),
+    ///         Book(title: "Right Ho Jeeves", author: "P.D. Mans")
     ///     ]
     ///
     ///     let fuse = Fuse()
@@ -416,11 +413,11 @@ extension Fuse {
             var scores = [Double]()
             var totalScore = 0.0
             
-            var propertyResults = [(key: String, score: Double, ranges: [CountableClosedRange<Int>])]()
+            var propertyResults = [(value: String, score: Double, ranges: [CountableClosedRange<Int>])]()
 
             item.properties.forEach { property in
 
-                let value = property.name
+                let value = property.value
                 
                 if let result = self.search(pattern, in: value) {
                     let weight = property.weight == 1 ? 1 : 1 - property.weight
@@ -429,7 +426,7 @@ extension Fuse {
                     
                     scores.append(score)
                     
-                    propertyResults.append((key: property.name, score: score, ranges: result.ranges))
+                    propertyResults.append((value: property.value, score: score, ranges: result.ranges))
                 }
             }
             
@@ -450,7 +447,7 @@ extension Fuse {
     
     /// Asynchronously searches for a text pattern in an array of `Fuseable` objects.
     ///
-    /// Each `FuseSearchable` object contains a `properties` accessor which returns `FuseProperty` array. Each `FuseProperty` is a tuple containing a `key` (the value of the property which should be included in the search), and a `weight` (how much "weight" to assign to the score)
+    /// Each `FuseSearchable` object contains a `properties` accessor which returns `FuseProperty` array. Each `FuseProperty` is a tuple containing a `value` (the value of the property which should be included in the search), and a `weight` (how much "weight" to assign to the score)
     ///
     /// ## Example
     ///
@@ -462,8 +459,8 @@ extension Fuse {
     ///
     ///         var properties: [FuseProperty] {
     ///             return [
-    ///                 FuseProperty(name: title, weight: 0.3),
-    ///                 FuseProperty(name: author, weight: 0.7),
+    ///                 FuseProperty(value: title, weight: 0.7),
+    ///                 FuseProperty(value: author, weight: 0.3)
     ///             ]
     ///         }
     ///     }
@@ -471,8 +468,8 @@ extension Fuse {
     /// Searching is straightforward:
     ///
     ///     let books: [Book] = [
-    ///         Book(author: "John X", title: "Old Man's War fiction"),
-    ///         Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+    ///         Book(title: "Old Man's War fiction", author: "John X"),
+    ///         Book(title: "Right Ho Jeeves", author: "P.D. Mans")
     ///     ]
     ///
     ///     let fuse = Fuse()
@@ -501,11 +498,11 @@ extension Fuse {
                     var scores = [Double]()
                     var totalScore = 0.0
                     
-                    var propertyResults = [(key: String, score: Double, ranges: [CountableClosedRange<Int>])]()
+                    var propertyResults = [(value: String, score: Double, ranges: [CountableClosedRange<Int>])]()
 
                     item.properties.forEach { property in
 
-                        let value = property.name
+                        let value = property.value
                         
                         if let result = self.search(pattern, in: value) {
                             let weight = property.weight == 1 ? 1 : 1 - property.weight
@@ -514,7 +511,7 @@ extension Fuse {
                             
                             scores.append(score)
                             
-                            propertyResults.append((key: property.name, score: score, ranges: result.ranges))
+                            propertyResults.append((value: property.value, score: score, ranges: result.ranges))
                         }
                     }
                     

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ struct Book: Fuseable {
 
     var properties: [FuseProperty] {
         return [
-            FuseProperty(name: title, weight: 0.3),
-            FuseProperty(name: author, weight: 0.7),
+            FuseProperty(value: title, weight: 0.3),
+            FuseProperty(value: author, weight: 0.7)
         ]
     }
 }
 
 let books: [Book] = [
-    Book(author: "John X", title: "Old Man's War fiction"),
-    Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+    Book(title: "Old Man's War fiction", author: "John X"),
+    Book(title: "Right Ho Jeeves", author: "P.D. Mans")
 ]
 let fuse = Fuse()
 let results = fuse.search("man", in: books)
@@ -92,12 +92,12 @@ results.forEach { item in
 // Output:
 //
 // index: 1
-// score: 0.015
-// results: [(key: "author", score: 0.015000000000000003, ranges: [CountableClosedRange(5...7)])]
+// score: 0.015000000000000003
+// results: [(value: "P.D. Mans", score: 0.015000000000000003, ranges: [CountableClosedRange(5...7)])]
 // ---------------
 // index: 0
-// score: 0.028
-// results: [(key: "title", score: 0.027999999999999997, ranges: [CountableClosedRange(4...6)])]
+// score: 0.027999999999999997
+// results: [(value: "Old Man\'s War fiction", score: 0.027999999999999997, ranges: [CountableClosedRange(4...6)])]
 ```
 
 ##### Asynchronous version


### PR DESCRIPTION
Fixes #33 which is a confusion caused by changes in #20.
@krisk This is a minor change and does not change behavior.